### PR TITLE
Fix missing raw tag in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a collection of stack templates the users can use to create a small stac
 
 The difference from a normal stacks are the following:
 - a template stack has in the `.config.yml` the field `template: true`
-- you can use jinja2 templates to conditionally alter the resulting stack
+- you can use `pongo2` templates to conditionally alter the resulting stack
 
 When the user creates a stack from template the BE will pass the following parameters:
 - stack_usecase

--- a/blank-sample/README.md
+++ b/blank-sample/README.md
@@ -5,19 +5,9 @@
 ## Stack templates READMEs
 
 When using stack templates, the README file of the template will be copied over to the stacks generated.  
-Like for other files of a template, it is possible to use Jinja templating inside the template `README.md` file. It will be compiled when users generate a stack from it.
+Like for other files of a template, it is possible to use `pongo2` templating inside the template `README.md` file. It will be compiled when users generate a stack from it.
 
 Some variables are exposed and can be used in READMEs to generate dynamic content.
-
-```jinja
-{% raw -%}
-Printing a variable value: {{ stack_usecase }}
-
-{% if stack_usecase == "foo" %}
-  Using expressions
-{% endif %}
-{%- endraw %}
-```
 
 **Available variables**
 

--- a/terraform-sample/README.md
+++ b/terraform-sample/README.md
@@ -5,19 +5,9 @@
 ## Stack templates READMEs
 
 When using stack templates, the README file of the template will be copied over to the stacks generated.  
-Like for other files of a template, it is possible to use Jinja templating inside the template `README.md` file. It will be compiled when users generate a stack from it.
+Like for other files of a template, it is possible to use `pongo2` templating inside the template `README.md` file. It will be compiled when users generate a stack from it.
 
 Some variables are exposed and can be used in READMEs to generate dynamic content.
-
-```jinja
-{% raw -%}
-Printing a variable value: {{ stack_usecase }}
-
-{% if stack_usecase == "foo" %}
-  Using expressions
-{% endif %}
-{%- endraw %}
-```
 
 **Available variables**
 


### PR DESCRIPTION
Remove templating example from templates README files. For some reason, we cannot use the `verbatim` tag either, although it's supposed to be implemented in pongo2.

Also, replaces mentions of `jinja` by `pongo2`, as pongo2 is not jinja compliant, but instead closer to django.